### PR TITLE
Fixes loading POIs from the Wikitude test web-service on iOS 9

### DIFF
--- a/Scripts/WikitudePhoneGapSampleGenerator.sh
+++ b/Scripts/WikitudePhoneGapSampleGenerator.sh
@@ -73,6 +73,8 @@ if [ "true" == "$BUILD_IOS" ]; then
 	
 	# Add location access description key/value to info.plist
 	/usr/libexec/PlistBuddy -c "Add :NSLocationWhenInUseUsageDescription string 'Accessing GPS information is needed to display POIs around your current location'" "${DESTINATION_DIRECTORY}"/../platforms/ios/"${PROJECT_NAME}"/"${PROJECT_NAME}"-Info.plist
+	/usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity dict " "${DESTINATION_DIRECTORY}"/../platforms/ios/"${PROJECT_NAME}"/"${PROJECT_NAME}"-Info.plist
+	/usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool 'YES'" "${DESTINATION_DIRECTORY}"/../platforms/ios/"${PROJECT_NAME}"/"${PROJECT_NAME}"-Info.plist
 	
 	# copy app icons
 	ICON_DESTINATION_PATH="${DESTINATION_DIRECTORY}"/../platforms/ios/"${PROJECT_NAME}"/Resources/icons


### PR DESCRIPTION
allows clear text http requests via setting NSAllowsArbitraryLoads to YES in the plist file